### PR TITLE
Jam Feedback Patch

### DIFF
--- a/Enemies/ImAStove.tscn
+++ b/Enemies/ImAStove.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://enemies/ImAStove.gd" type="Script" id=1]
 [ext_resource path="res://utilities/attachable_tools/Hit_Box.tscn" type="PackedScene" id=2]
@@ -39,6 +39,33 @@ tracks/1/keys = {
 "transitions": PoolRealArray( 1 ),
 "update": 1,
 "values": [ true ]
+}
+
+[sub_resource type="Animation" id=10]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/path = NodePath("../Sprite:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ true ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath(".:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ false ]
 }
 
 [sub_resource type="RectangleShape2D" id=6]
@@ -208,9 +235,12 @@ position = Vector2( 0, -5 )
 scale = Vector2( 0.45, 0.45 )
 texture = ExtResource( 7 )
 hframes = 6
+frame = 5
 
 [node name="AtkSpritePlayer" type="AnimationPlayer" parent="Stove/Atk_Sprite"]
+autoplay = "RESET"
 anims/Attack = SubResource( 9 )
+anims/RESET = SubResource( 10 )
 
 [node name="AtkAudio" type="AudioStreamPlayer2D" parent="Stove/Atk_Sprite"]
 stream = ExtResource( 8 )
@@ -226,6 +256,7 @@ position = Vector2( 0, 5.8125 )
 shape = SubResource( 6 )
 
 [node name="Label" type="Label" parent="."]
+visible = false
 margin_left = -44.0
 margin_top = -161.0
 margin_right = 41.0

--- a/Enemies/Lamp.tscn
+++ b/Enemies/Lamp.tscn
@@ -301,7 +301,6 @@ position = Vector2( 76, 2 )
 scale = Vector2( 0.5, 0.5 )
 
 [node name="Label" type="Label" parent="."]
-visible = false
 margin_left = -55.0
 margin_top = -184.0
 margin_right = 55.0

--- a/addons/toolbox_project/defaults/screens/ScreenAbout.gd
+++ b/addons/toolbox_project/defaults/screens/ScreenAbout.gd
@@ -1,1 +1,7 @@
 extends Screen
+
+
+func _on_Credits_meta_clicked(meta):
+	# `meta` is not guaranteed to be a String, so convert it to a String
+	# to avoid script errors at run-time.
+	OS.shell_open(str(meta))

--- a/addons/toolbox_project/defaults/screens/ScreenAbout.tscn
+++ b/addons/toolbox_project/defaults/screens/ScreenAbout.tscn
@@ -19,16 +19,16 @@ script = ExtResource( 6 )
 [node name="VBoxContainer" type="VBoxContainer" parent="MenuLayer/UIBox" index="0"]
 margin_left = 220.0
 margin_top = 80.0
-margin_right = 804.0
-margin_bottom = 520.0
+margin_right = 1060.0
+margin_bottom = 640.0
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Panel" type="Panel" parent="MenuLayer/UIBox/VBoxContainer" index="0"]
-margin_right = 584.0
-margin_bottom = 375.0
+margin_right = 840.0
+margin_bottom = 517.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -37,20 +37,17 @@ anchor_left = 0.1
 anchor_top = 0.1
 anchor_right = 0.9
 anchor_bottom = 0.9
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelBig" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="0" instance=ExtResource( 4 )]
 anchor_right = 0.0
-margin_right = 467.0
-margin_bottom = 41.0
+margin_right = 672.0
+margin_bottom = 70.0
 text = "Created by"
 
 [node name="Label2" type="Label" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="1"]
-margin_top = 57.0
-margin_right = 467.0
-margin_bottom = 89.0
+margin_top = 86.0
+margin_right = 672.0
+margin_bottom = 132.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Tommy Wiseau"
@@ -58,15 +55,15 @@ valign = 1
 
 [node name="LabelBig2" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="2" instance=ExtResource( 4 )]
 anchor_right = 0.0
-margin_top = 105.0
-margin_right = 467.0
-margin_bottom = 146.0
+margin_top = 148.0
+margin_right = 672.0
+margin_bottom = 218.0
 text = "Sprites by"
 
 [node name="Label3" type="Label" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="3"]
-margin_top = 162.0
-margin_right = 467.0
-margin_bottom = 194.0
+margin_top = 234.0
+margin_right = 672.0
+margin_bottom = 280.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Tommy Wiseau"
@@ -74,24 +71,24 @@ valign = 1
 
 [node name="LabelBig3" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="4" instance=ExtResource( 4 )]
 anchor_right = 0.0
-margin_top = 210.0
-margin_right = 467.0
-margin_bottom = 251.0
+margin_top = 296.0
+margin_right = 672.0
+margin_bottom = 366.0
 text = "Sounds by"
 
 [node name="Label5" type="Label" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="5"]
-margin_top = 267.0
-margin_right = 467.0
-margin_bottom = 300.0
+margin_top = 382.0
+margin_right = 672.0
+margin_bottom = 428.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Tommy Wiseau"
 valign = 1
 
 [node name="BtnBack" parent="MenuLayer/UIBox/VBoxContainer" index="1" instance=ExtResource( 5 )]
-margin_top = 391.0
-margin_right = 584.0
-margin_bottom = 440.0
+margin_top = 533.0
+margin_right = 840.0
+margin_bottom = 560.0
 text = "Back"
 pushes_screen = false
 screen_to_push_in_config = ""

--- a/addons/toolbox_project/scenes/ui/game/dialog/GameDialog.gd
+++ b/addons/toolbox_project/scenes/ui/game/dialog/GameDialog.gd
@@ -77,10 +77,15 @@ func __show(show=true):
 	if show:
 		if has_node("EyeClose/AnimationPlayer"):
 			$EyeClose/AnimationPlayer.play("rest")
-		for btn in root_btns.get_children():
-			if btn is Button and btn.visible:
-				btn.grab_focus()
-				break
+		if Settings.sanityValue <= 0:
+			$CenterContainer/Popup/VBoxContainer/GameOverLabel.text = "Your sanity hit 0, but..."
+		else:
+			$CenterContainer/Popup/VBoxContainer/GameOverLabel.text = "Your alertness hit 0, but..."
+		
+		#for btn in root_btns.get_children():
+		#	if btn is Button and btn.visible:
+		#		btn.grab_focus()
+		#		break
 
 func __hide():
 	__show(false)
@@ -123,4 +128,5 @@ func _on_BtnSettings_pressed():
 	ScreenMngr.push_screen(C.SCREEN_OPTIONS_MENU)
 
 func _on_BtnScore_pressed():
+	SoundMngr.play_ui_sound(C.UI_SELECT)
 	$SubmitScorePanel.popup()

--- a/addons/toolbox_project/scenes/ui/game/dialog/GameDialog.tscn
+++ b/addons/toolbox_project/scenes/ui/game/dialog/GameDialog.tscn
@@ -1,9 +1,16 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/toolbox_project/assets/theme.tres" type="Theme" id=1]
 [ext_resource path="res://addons/toolbox_project/scenes/ui/components/LabelBig.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/toolbox_project/scenes/ui/game/dialog/GameDialog.gd" type="Script" id=3]
 [ext_resource path="res://screens/SubmitScorePanel.tscn" type="PackedScene" id=4]
+[ext_resource path="res://assets/fonts/sofija.regular.ttf" type="DynamicFontData" id=5]
+
+[sub_resource type="DynamicFont" id=1]
+size = 30
+outline_size = 1
+outline_color = Color( 0.0666667, 0.364706, 0.509804, 1 )
+font_data = ExtResource( 5 )
 
 [node name="GameDialog" type="CanvasLayer"]
 pause_mode = 2
@@ -46,6 +53,13 @@ size_flags_vertical = 4
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="GameOverLabel" type="Label" parent="CenterContainer/Popup/VBoxContainer"]
+visible = false
+margin_right = 40.0
+margin_bottom = 46.0
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+custom_fonts/font = SubResource( 1 )
 
 [node name="LabelBig" parent="CenterContainer/Popup/VBoxContainer" instance=ExtResource( 2 )]
 anchor_right = 0.0
@@ -98,7 +112,6 @@ text = "Quit game"
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 
 [node name="SubmitScorePanel" parent="." instance=ExtResource( 4 )]
-visible = false
 
 [connection signal="pressed" from="InvisibleWall" to="." method="_on_InvisibleWall_pressed"]
 [connection signal="pressed" from="CenterContainer/Popup/VBoxContainer/BtnResume" to="." method="_on_BtnResume_pressed"]

--- a/addons/toolbox_project/scenes/ui/game/dialog/GameDialogWon.tscn
+++ b/addons/toolbox_project/scenes/ui/game/dialog/GameDialogWon.tscn
@@ -65,7 +65,7 @@ signal_to_open_to = "level_won"
 
 [node name="EyeClose" type="Sprite" parent="." index="0"]
 visible = false
-scale = Vector2( 0.426049, 0.429164 )
+scale = Vector2( 0.45, 0.429 )
 texture = ExtResource( 2 )
 centered = false
 hframes = 4
@@ -80,43 +80,45 @@ anims/rest = SubResource( 2 )
 margin_right = 495.0
 margin_bottom = 412.0
 
-[node name="LabelBig" parent="CenterContainer/Popup/VBoxContainer" index="0"]
-margin_right = 471.0
-margin_bottom = 216.0
+[node name="GameOverLabel" parent="CenterContainer/Popup/VBoxContainer" index="0"]
+visible = true
+align = 1
+
+[node name="LabelBig" parent="CenterContainer/Popup/VBoxContainer" index="1"]
 text = "You've won!
-its ok to slow down 
+Its ok to slow down 
 sometimes"
 
-[node name="BtnResume" parent="CenterContainer/Popup/VBoxContainer" index="1"]
+[node name="BtnResume" parent="CenterContainer/Popup/VBoxContainer" index="2"]
 visible = false
 
-[node name="BtnScore" parent="CenterContainer/Popup/VBoxContainer" index="2"]
+[node name="BtnScore" parent="CenterContainer/Popup/VBoxContainer" index="3"]
 margin_top = 232.0
 margin_right = 471.0
 margin_bottom = 259.0
 
-[node name="BtnRetry" parent="CenterContainer/Popup/VBoxContainer" index="3"]
+[node name="BtnRetry" parent="CenterContainer/Popup/VBoxContainer" index="4"]
 margin_top = 275.0
 margin_right = 471.0
 margin_bottom = 302.0
 
-[node name="BtnNext" parent="CenterContainer/Popup/VBoxContainer" index="4"]
+[node name="BtnNext" parent="CenterContainer/Popup/VBoxContainer" index="5"]
 visible = false
 margin_top = 129.0
 margin_right = 376.0
 margin_bottom = 156.0
 
-[node name="BtnSettings" parent="CenterContainer/Popup/VBoxContainer" index="5"]
+[node name="BtnSettings" parent="CenterContainer/Popup/VBoxContainer" index="6"]
 visible = false
 margin_top = 122.0
 margin_bottom = 171.0
 
-[node name="BtnMenu" parent="CenterContainer/Popup/VBoxContainer" index="6"]
+[node name="BtnMenu" parent="CenterContainer/Popup/VBoxContainer" index="7"]
 margin_top = 318.0
 margin_right = 471.0
 margin_bottom = 345.0
 
-[node name="BtnQuit" parent="CenterContainer/Popup/VBoxContainer" index="7"]
+[node name="BtnQuit" parent="CenterContainer/Popup/VBoxContainer" index="8"]
 margin_top = 361.0
 margin_right = 471.0
 margin_bottom = 388.0

--- a/dialogic/folder_structure.json
+++ b/dialogic/folder_structure.json
@@ -138,7 +138,7 @@
 					},
 					"metadata": {
 						"color": null,
-						"folded": false
+						"folded": true
 					}
 				},
 				"Random Work": {
@@ -155,7 +155,7 @@
 					},
 					"metadata": {
 						"color": null,
-						"folded": false
+						"folded": true
 					}
 				},
 				"Stimulants": {

--- a/dialogic/settings.cfg
+++ b/dialogic/settings.cfg
@@ -8,6 +8,7 @@ default_action_key="ui_primaryclick"
 autofocus_choices=false
 delay_after_options="0.5"
 enable_default_shortcut=true
+clicking_dialog_action=true
 
 [editor]
 

--- a/dialogic/timelines/timeline-1648944806.json
+++ b/dialogic/timelines/timeline-1648944806.json
@@ -54,7 +54,7 @@
 				"arguments": [
 					"15"
 				],
-				"method_name": "adjust_sanity",
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1648944814.json
+++ b/dialogic/timelines/timeline-1648944814.json
@@ -54,7 +54,7 @@
 				"arguments": [
 					"20"
 				],
-				"method_name": "adjust_sanity",
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1648944820.json
+++ b/dialogic/timelines/timeline-1648944820.json
@@ -54,7 +54,7 @@
 				"arguments": [
 					"25"
 				],
-				"method_name": "adjust_sanity",
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1648954775.json
+++ b/dialogic/timelines/timeline-1648954775.json
@@ -51,6 +51,10 @@
 			"event_id": "dialogic_042"
 		},
 		{
+			"event_id": "dialogic_022",
+			"transition_duration": 1
+		},
+		{
 			"choice": "I'm trying NOT to sleep.",
 			"condition": "",
 			"definition": "",

--- a/dialogic/timelines/timeline-1649077433.json
+++ b/dialogic/timelines/timeline-1649077433.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"-1"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_sanity",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -43,6 +43,16 @@
 					"50"
 				],
 				"method_name": "adjust_score",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1649077481.json
+++ b/dialogic/timelines/timeline-1649077481.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"-1"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_sanity",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -43,6 +43,16 @@
 					"50"
 				],
 				"method_name": "adjust_score",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1649077499.json
+++ b/dialogic/timelines/timeline-1649077499.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"50"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_score",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -40,9 +40,19 @@
 		{
 			"call_node": {
 				"arguments": [
-					"50"
+					"-1"
 				],
-				"method_name": "adjust_score",
+				"method_name": "adjust_sanity",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1649077508.json
+++ b/dialogic/timelines/timeline-1649077508.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"50"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_score",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -40,9 +40,19 @@
 		{
 			"call_node": {
 				"arguments": [
-					"50"
+					"-1"
 				],
-				"method_name": "adjust_score",
+				"method_name": "adjust_sanity",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1649077518.json
+++ b/dialogic/timelines/timeline-1649077518.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"50"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_score",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -40,9 +40,19 @@
 		{
 			"call_node": {
 				"arguments": [
-					"50"
+					"-1"
 				],
-				"method_name": "adjust_score",
+				"method_name": "adjust_sanity",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/dialogic/timelines/timeline-1649077639.json
+++ b/dialogic/timelines/timeline-1649077639.json
@@ -30,9 +30,9 @@
 		{
 			"call_node": {
 				"arguments": [
-					"-50"
+					"50"
 				],
-				"method_name": "adjust_alertness",
+				"method_name": "adjust_score",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"
@@ -40,9 +40,19 @@
 		{
 			"call_node": {
 				"arguments": [
-					"50"
+					"-1"
 				],
-				"method_name": "adjust_score",
+				"method_name": "adjust_sanity",
+				"target_node_path": "/root/Settings"
+			},
+			"event_id": "dialogic_042"
+		},
+		{
+			"call_node": {
+				"arguments": [
+					"-10"
+				],
+				"method_name": "adjust_alertness",
 				"target_node_path": "/root/Settings"
 			},
 			"event_id": "dialogic_042"

--- a/enemies/ChaseEnemy.gd
+++ b/enemies/ChaseEnemy.gd
@@ -7,13 +7,16 @@ onready var hitbox := $Hit_Box
 var playerRef
 var delayTimer
 var VELOCITY
-var SPEED := 25.0
+var SPEED := 35.0
 var curSpeed := 25.0
 var speedBonus := 0.0
 var stallCounter := 0.0
 
 var amEating = false
 var amActive = false
+var activating = false
+var activateCount = 0
+var activateDelay = 2
 
 var sprite_dir = "right"			#where we are actually facing. A string for anim
 var facing_dir = Vector2.DOWN	#where we are facing in vector notation
@@ -28,14 +31,23 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	stallCounter += delta
+	if (Settings.curGameState == Settings.GAME_STATES.PLAY or Settings.curGameState == Settings.GAME_STATES.BATTLE) and !amEating and !amActive and Settings.gameOver == false:
+		if activating and !amActive:
+			activateCount += delta
+		if !amActive and activateCount >= activateDelay:
+			amActive = true
+			curSpeed = SPEED + (Settings.roomsExplored * 3.5)
+			show()
+			$RoomEnter.emitting = true
+			$AmbientNoise.play()
 	
-	if stallCounter >= 10:
-		stallCounter = 0.0
-		speedBonus += 3.0
-		speedBonus = clamp(speedBonus, 0.0, 50.0)
-		
-	if (Settings.curGameState == Settings.GAME_STATES.PLAY or Settings.curGameState == Settings.GAME_STATES.BATTLE or Settings.curGameState == Settings.GAME_STATES.DIALOG) and !amEating and amActive and Settings.gameOver == false:
+	if (Settings.curGameState == Settings.GAME_STATES.PLAY or Settings.curGameState == Settings.GAME_STATES.BATTLE) and !amEating and amActive and Settings.gameOver == false:
+		stallCounter += delta
+	
+		if stallCounter >= 10:
+			stallCounter = 0.0
+			speedBonus += 3.0
+			speedBonus = clamp(speedBonus, 0.0, 50.0)
 		
 		if Settings.curGameState == Settings.GAME_STATES.BATTLE or Settings.curGameState == Settings.GAME_STATES.DIALOG:
 			curSpeed = (SPEED + (Settings.roomsExplored * 3)) / 3
@@ -59,12 +71,8 @@ func _process(delta):
 
 
 func activate(delay: int):
-	yield(get_tree().create_timer(delay), "timeout")
-	amActive = true
-	curSpeed = SPEED + (Settings.roomsExplored * 3.5)
-	show()
-	$RoomEnter.emitting = true
-	$AmbientNoise.play()
+	activateDelay = delay
+	activating = true
 
 
 func anim_switch(animation, speed = 1):

--- a/enemies/ChaseEnemy.tscn
+++ b/enemies/ChaseEnemy.tscn
@@ -391,6 +391,7 @@ collision_mask = 0
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]
+position = Vector2( 10, -73 )
 texture = ExtResource( 1 )
 hframes = 3
 vframes = 6
@@ -400,10 +401,11 @@ frame = 1
 local_coords = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 3, 24.5 )
+position = Vector2( 0, -33 )
 shape = SubResource( 5 )
 
 [node name="Hit_Box" parent="." instance=ExtResource( 3 )]
+position = Vector2( 0, -49 )
 collision_layer = 0
 collision_mask = 2
 

--- a/game/GameMain.gd
+++ b/game/GameMain.gd
@@ -83,6 +83,7 @@ func random_room():
 
 
 func change_room(newRoom: String, directionFrom: String, _delay=2):
+	
 	var doorLocation
 	if directionFrom == 'w':
 		doorLocation = curRoom.get_node("Interactables/DoorWestClickable").interactionPosition
@@ -125,6 +126,7 @@ func change_room(newRoom: String, directionFrom: String, _delay=2):
 	Settings.roomsExplored += 1
 	curRoomString = newRoom
 	add_child(curRoom)
+	
 	yield(get_tree(), "idle_frame")
 	curRoom._set_spawns(directionFrom, newDelay)
 

--- a/levels/BaseLevel.gd
+++ b/levels/BaseLevel.gd
@@ -26,6 +26,7 @@ export (bool) var freezeInput = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	Settings.curGameState = Settings.GAME_STATES.LOADING
 	var clickables = $Interactables.get_children()
 	var _err = player.connect("arrived", self, '_on_player_arrived')
 	
@@ -41,8 +42,6 @@ func _ready():
 		var bgValue = .6 - Settings.difficulty / 10.0
 		child.modulate = Color(rValue, bgValue, bgValue, child.modulate.a)
 	
-	Settings.curGameState = Settings.GAME_STATES.PLAY
-	
 	if Settings.difficulty == 1:
 		bgSprite.texture = load('res://assets/bg01.png')
 		$Difficulty2.queue_free()
@@ -52,6 +51,8 @@ func _ready():
 		$Difficulty3.queue_free()
 	elif Settings.difficulty == 3:
 		bgSprite.texture = load('res://assets/bg03.png')
+		
+	Settings.curGameState = Settings.GAME_STATES.PLAY
 
 
 func _set_spawns(directionFrom: String, delay=2):
@@ -72,7 +73,10 @@ func _set_spawns(directionFrom: String, delay=2):
 		enemy.activate(delay)
 
 
+
 func _on_Area2D_mouse_entered(clickable):
+	if clickable == null:
+		return
 	if clickable != currentEvent:
 		_on_Area2D_mouse_exited(currentEvent)
 	if clickable.canClick:
@@ -138,6 +142,8 @@ func _on_player_arrived():
 
 func process_event(event : Interactable) -> bool: 
 	var eventResult = false
+	if event == null:
+		return eventResult
 	
 	if player.global_position.distance_to(event.interactionPosition) < gapMargin or event.reroute_after_dialog:
 		event.runEvent()
@@ -157,6 +163,7 @@ func _process(_delta):
 		Settings.curGameState = Settings.GAME_STATES.MENU
 		SignalMngr.emit_signal("level_won")
 
+
 func _unhandled_input(event):
 	if freezeInput or Settings.curGameState != Settings.GAME_STATES.PLAY:
 		return
@@ -173,8 +180,10 @@ func _unhandled_input(event):
 		return
 	
 	if event.is_action_pressed("ui_primaryclick"):
+		# First click of a new game has to start a bunch of stuff
 		if Settings.gameStarted == false:
 			Settings.gameStarted = true
+			enemy.global_position = Vector2(203, 223)
 			enemy.activate(3)
 			
 		if currentEvent != null:

--- a/levels/BaseRoom.tscn
+++ b/levels/BaseRoom.tscn
@@ -59,18 +59,19 @@ tile_set = ExtResource( 2 )
 format = 1
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
-position = Vector2( 289, 342 )
-SPEED = 75
+position = Vector2( 164, 311 )
+SPEED = 85
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 position = Vector2( 3, -44 )
 current = true
 zoom = Vector2( 0.75, 0.75 )
+smoothing_enabled = true
 
 [node name="Floating_Text_Manager" parent="Player" instance=ExtResource( 4 )]
 position = Vector2( -3, -151 )
 
-[node name="Interactables" type="Node2D" parent="."]
+[node name="Interactables" type="YSort" parent="."]
 
 [node name="Line2D" type="Line2D" parent="."]
 width = 2.0

--- a/levels/CatLampTalk.tscn
+++ b/levels/CatLampTalk.tscn
@@ -15,7 +15,6 @@ shader_param/brightness = 1.0
 extents = Vector2( 35.5, 43.5 )
 
 [node name="CatLampTalk" instance=ExtResource( 1 )]
-z_index = 2
 script = ExtResource( 5 )
 canHighlight = true
 canClick = true
@@ -23,10 +22,15 @@ isOneShot = true
 
 [node name="Sprite" parent="." index="0"]
 material = SubResource( 2 )
+position = Vector2( 1, -44 )
 scale = Vector2( 0.05, 0.05 )
 texture = ExtResource( 2 )
 
 [node name="CollisionShape2D" parent="." index="1"]
+position = Vector2( 1, -43 )
 shape = SubResource( 1 )
+
+[node name="InteractionPosition" parent="." index="2"]
+position = Vector2( 0, 6 )
 
 [node name="DialogEvent" parent="EventQueue" index="0" instance=ExtResource( 4 )]

--- a/levels/floatingtext/Floating_Text.tscn
+++ b/levels/floatingtext/Floating_Text.tscn
@@ -6,6 +6,7 @@
 [sub_resource type="DynamicFont" id=1]
 size = 25
 outline_size = 1
+outline_color = Color( 0, 0, 0, 1 )
 font_data = ExtResource( 2 )
 
 [node name="Floating_Text" type="Position2D"]
@@ -15,6 +16,7 @@ script = ExtResource( 1 )
 margin_right = 40.0
 margin_bottom = 14.0
 custom_colors/font_outline_modulate = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_fonts/font = SubResource( 1 )
 text = "Placeholder"
 

--- a/levels/interactables/clickable/BedClickable.tscn
+++ b/levels/interactables/clickable/BedClickable.tscn
@@ -21,21 +21,20 @@ canClick = true
 
 [node name="Sprite" parent="." index="0"]
 material = SubResource( 1 )
-position = Vector2( 153.06, 215.603 )
-scale = Vector2( 2.0812, 2.97826 )
+position = Vector2( 35, -43 )
+scale = Vector2( 2, 2 )
 texture = ExtResource( 3 )
 
 [node name="CollisionShape2D" parent="." index="1"]
-position = Vector2( 151.5, 217.5 )
+position = Vector2( 37, -45 )
 shape = SubResource( 2 )
 
 [node name="InteractionPosition" parent="." index="2"]
-position = Vector2( -45, 223 )
+position = Vector2( -92, 28 )
 
 [node name="EventQueue" parent="." index="3"]
 position = Vector2( 23, -7 )
 
 [node name="DialogEvent" parent="EventQueue" index="0" instance=ExtResource( 1 )]
 position = Vector2( -12, 12 )
-difficulty = -1
 DIALOG = "Bed"

--- a/levels/interactables/clickable/Cellphone.tscn
+++ b/levels/interactables/clickable/Cellphone.tscn
@@ -38,7 +38,7 @@ colors = PoolColorArray( 0.388235, 0.862745, 1, 0, 0.386047, 0.886428, 0.898438,
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 4 )
-frame = 13
+frame = 2
 playing = true
 
 [node name="CPUParticles2D" type="CPUParticles2D" parent="AnimatedSprite"]

--- a/levels/interactables/clickable/CellphoneClickable.tscn
+++ b/levels/interactables/clickable/CellphoneClickable.tscn
@@ -13,7 +13,7 @@ shader = ExtResource( 4 )
 shader_param/brightness = 1.0
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 16, 17.25 )
+extents = Vector2( 20.5, 20.5 )
 
 [node name="CellphoneClickable" instance=ExtResource( 2 )]
 script = ExtResource( 6 )
@@ -22,16 +22,18 @@ canClick = true
 isOneShot = true
 
 [node name="Cellphone" parent="." index="0" instance=ExtResource( 5 )]
+position = Vector2( -5, -15 )
 scale = Vector2( 0.246786, 0.246786 )
 
 [node name="Sprite" parent="." index="1"]
 material = SubResource( 1 )
-position = Vector2( 9.53674e-07, -1.78814e-06 )
+position = Vector2( -4, -15 )
 scale = Vector2( 0.253968, 0.253968 )
 texture = ExtResource( 3 )
 hframes = 3
 
 [node name="CollisionShape2D" parent="." index="2"]
+position = Vector2( 0, -15 )
 shape = SubResource( 2 )
 
 [node name="InteractionPosition" parent="." index="3"]

--- a/levels/interactables/clickable/FloorLampClickable.tscn
+++ b/levels/interactables/clickable/FloorLampClickable.tscn
@@ -21,21 +21,21 @@ canClick = true
 
 [node name="Sprite" parent="." index="0"]
 material = SubResource( 1 )
+position = Vector2( 0, -69 )
 scale = Vector2( 1.5, 1.5 )
 texture = ExtResource( 3 )
 hframes = 6
 
 [node name="CollisionShape2D" parent="." index="1"]
-position = Vector2( 2, 11 )
+position = Vector2( 1, -56 )
 shape = SubResource( 2 )
 
 [node name="InteractionPosition" parent="." index="2"]
-position = Vector2( -5, 83 )
+position = Vector2( 4, 30 )
 
 [node name="EventQueue" parent="." index="3"]
 position = Vector2( 1, -8 )
 
 [node name="DialogEvent" parent="EventQueue" index="0" instance=ExtResource( 1 )]
 position = Vector2( 1, 35 )
-difficulty = -1
 DIALOG = "Floor Lamp"

--- a/levels/noninteractables/Rug.tscn
+++ b/levels/noninteractables/Rug.tscn
@@ -3,17 +3,14 @@
 [ext_resource path="res://assets/rug.png" type="Texture" id=1]
 
 [sub_resource type="AtlasTexture" id=1]
-flags = 4
 atlas = ExtResource( 1 )
 region = Rect2( 0, 0, 193, 192 )
 
 [sub_resource type="AtlasTexture" id=2]
-flags = 4
 atlas = ExtResource( 1 )
 region = Rect2( 386, 0, 193, 192 )
 
 [sub_resource type="AtlasTexture" id=3]
-flags = 4
 atlas = ExtResource( 1 )
 region = Rect2( 193, 0, 193, 192 )
 
@@ -29,6 +26,6 @@ animations = [ {
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 4 )
-frame = 5
+frame = 11
 speed_scale = 0.1
 playing = true

--- a/levels/rooms/BedRoom.tscn
+++ b/levels/rooms/BedRoom.tscn
@@ -89,21 +89,21 @@ tile_data = PoolIntArray( -196609, 68, 0, 786657, 68, 0 )
 position = Vector2( 876, 239 )
 
 [node name="DoorNorthClickable" parent="Interactables" index="0" instance=ExtResource( 6 )]
-position = Vector2( 339, -18 )
+position = Vector2( 518, 57 )
 canHighlight = true
 canClick = true
 
 [node name="Sprite" parent="Interactables/DoorNorthClickable" index="0"]
 material = SubResource( 3 )
-position = Vector2( 160, 12 )
+position = Vector2( -4, -58 )
 texture = ExtResource( 3 )
 
 [node name="CollisionShape2D" parent="Interactables/DoorNorthClickable" index="1"]
-position = Vector2( 161, 19 )
+position = Vector2( -4, -59 )
 shape = SubResource( 4 )
 
 [node name="InteractionPosition" parent="Interactables/DoorNorthClickable" index="2"]
-position = Vector2( 164, 103 )
+position = Vector2( 9, 18 )
 
 [node name="DialogEvent" parent="Interactables/DoorNorthClickable/EventQueue" index="0" instance=ExtResource( 7 )]
 difficulty = 1
@@ -118,22 +118,22 @@ difficulty = 3
 DIALOG = "RandomRoom"
 
 [node name="DoorEastClickable" parent="Interactables" index="1" instance=ExtResource( 6 )]
-position = Vector2( 512, -94 )
+position = Vector2( 988, 82 )
 canHighlight = true
 canClick = true
 
 [node name="Sprite" parent="Interactables/DoorEastClickable" index="0"]
 material = SubResource( 5 )
-position = Vector2( 476, 124 )
+position = Vector2( 4, -51 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 4 )
 
 [node name="CollisionShape2D" parent="Interactables/DoorEastClickable" index="1"]
-position = Vector2( 475.25, 120.313 )
+position = Vector2( 3, -57 )
 shape = SubResource( 6 )
 
 [node name="InteractionPosition" parent="Interactables/DoorEastClickable" index="2"]
-position = Vector2( 443, 193 )
+position = Vector2( -22, 18 )
 
 [node name="EventQueue" parent="Interactables/DoorEastClickable" index="3"]
 position = Vector2( 453, 10 )
@@ -218,7 +218,7 @@ difficulty = 3
 DIALOG = "RandomRoom"
 
 [node name="BedClickable" parent="Interactables" index="4" instance=ExtResource( 5 )]
-position = Vector2( 1042, -74 )
+position = Vector2( 1168, 230 )
 
 [node name="LightSwitchClickable" parent="Interactables" index="5" instance=ExtResource( 14 )]
 position = Vector2( 873, 6 )
@@ -272,8 +272,6 @@ position = Vector2( 357, 120 )
 
 [node name="PeekingRug" parent="." index="8" instance=ExtResource( 18 )]
 position = Vector2( 530, 94 )
-scale = Vector2( 0.75, 0.75 )
-z_index = 1
 
 [node name="FishPoster" parent="." index="9" instance=ExtResource( 16 )]
 position = Vector2( 707, -28 )

--- a/levels/rooms/HallwayRoom.tscn
+++ b/levels/rooms/HallwayRoom.tscn
@@ -71,21 +71,21 @@ tile_data = PoolIntArray( 5, 54, 0, 6, 46, 0, 65541, 55, 0, 65542, 47, 0, 65543,
 position = Vector2( 1679, 297 )
 
 [node name="DoorNorthClickable" parent="Interactables" index="0" instance=ExtResource( 5 )]
-position = Vector2( 1062, 112 )
+position = Vector2( 1210, 191 )
 canHighlight = true
 canClick = true
 
 [node name="Sprite" parent="Interactables/DoorNorthClickable" index="0"]
 material = SubResource( 3 )
-position = Vector2( 160, 12 )
+position = Vector2( 4, -62 )
 texture = ExtResource( 2 )
 
 [node name="CollisionShape2D" parent="Interactables/DoorNorthClickable" index="1"]
-position = Vector2( 159, 11 )
+position = Vector2( 3, -63 )
 shape = SubResource( 4 )
 
 [node name="InteractionPosition" parent="Interactables/DoorNorthClickable" index="2"]
-position = Vector2( 164, 103 )
+position = Vector2( 5, 9 )
 
 [node name="DialogEvent" parent="Interactables/DoorNorthClickable/EventQueue" index="0" instance=ExtResource( 6 )]
 difficulty = 1

--- a/levels/rooms/KitchenRoom.tscn
+++ b/levels/rooms/KitchenRoom.tscn
@@ -208,16 +208,19 @@ position = Vector2( 828, -12 )
 [node name="CoffeeClickable" parent="Interactables" index="5" instance=ExtResource( 11 )]
 position = Vector2( 294, 187 )
 
-[node name="LightSwitchClickable" parent="Interactables" index="6" instance=ExtResource( 12 )]
+[node name="CoffeeClickable2" parent="Interactables" index="6" instance=ExtResource( 11 )]
+position = Vector2( 933, 42 )
+
+[node name="LightSwitchClickable" parent="Interactables" index="7" instance=ExtResource( 12 )]
 position = Vector2( 733, 84 )
 
-[node name="CellphoneClickable" parent="Interactables" index="7" instance=ExtResource( 24 )]
+[node name="CellphoneClickable" parent="Interactables" index="8" instance=ExtResource( 24 )]
 position = Vector2( 805, 39 )
 
-[node name="CellphoneClickable2" parent="Interactables" index="8" instance=ExtResource( 24 )]
+[node name="CellphoneClickable2" parent="Interactables" index="9" instance=ExtResource( 24 )]
 position = Vector2( 820, 226 )
 
-[node name="CatLampTalk" parent="Interactables" index="9" instance=ExtResource( 25 )]
+[node name="CatLampTalk" parent="Interactables" index="10" instance=ExtResource( 25 )]
 position = Vector2( 283, 148 )
 
 [node name="ChaseEnemy" parent="." index="4"]

--- a/levels/rooms/LivingRoom.tscn
+++ b/levels/rooms/LivingRoom.tscn
@@ -70,21 +70,21 @@ modulate = Color( 1, 1, 1, 0.3 )
 tile_data = PoolIntArray( 65531, 47, 0, 65532, 46, 0, 131067, 20, 0, 131068, 47, 0, 131069, 46, 0, 196603, 55, 0, 196604, 20, 0, 196605, 47, 0, 196606, 46, 0, 262139, 48, 0, 262140, 20, 0, 262141, 20, 0, 262142, 47, 0, 262143, 26, 0, 196608, 26, 0, 196609, 26, 0, 196610, 45, 0, 196611, 46, 0, 327676, 48, 0, 327677, 20, 0, 327678, 20, 0, 327679, 27, 0, 262144, 34, 0, 262145, 34, 0, 262146, 33, 0, 262147, 47, 0, 262148, 46, 0, 393213, 48, 0, 393214, 20, 0, 393215, 28, 0, 327680, 19, 0, 327681, 19, 0, 327682, 32, 0, 327683, 55, 0, 327684, 47, 0, 327685, 26, 0, 327686, 26, 0, 327687, 26, 0, 327688, 26, 0, 327689, 26, 0, 327690, 26, 0, 327691, 26, 0, 327692, 26, 0, 327693, 26, 0, 327694, 26, 0, 327695, 26, 0, 327696, 26, 0, 327697, 26, 0, 327698, 26, 0, 327699, 26, 0, 327700, 45, 0, 458750, 49, 0, 458751, 29, 0, 393216, 30, 0, 393217, 30, 0, 393218, 31, 0, 393219, 55, 0, 393220, 51, 0, 393221, 27, 0, 393222, 34, 0, 393223, 34, 0, 393224, 34, 0, 393225, 34, 0, 393226, 34, 0, 393227, 34, 0, 393228, 34, 0, 393229, 34, 0, 393230, 34, 0, 393231, 34, 0, 393232, 34, 0, 393233, 34, 0, 393234, 34, 0, 393235, 34, 0, 393236, 33, 0, 458755, 48, 0, 458756, 51, 0, 458757, 28, 0, 458758, 19, 0, 458759, 19, 0, 458760, 19, 0, 458761, 19, 0, 458762, 19, 0, 458763, 19, 0, 458764, 19, 0, 458765, 19, 0, 458766, 19, 0, 458767, 19, 0, 458768, 19, 0, 458769, 19, 0, 458770, 19, 0, 458771, 19, 0, 458772, 32, 0, 524292, 49, 0, 524293, 29, 0, 524294, 30, 0, 524295, 30, 0, 524296, 30, 0, 524297, 30, 0, 524298, 30, 0, 524299, 30, 0, 524300, 30, 0, 524301, 30, 0, 524302, 30, 0, 524303, 30, 0, 524304, 30, 0, 524305, 30, 0, 524306, 30, 0, 524307, 30, 0, 524308, 31, 0 )
 
 [node name="DoorNorthClickable" parent="Interactables" index="0" instance=ExtResource( 2 )]
-position = Vector2( 313, -69 )
+position = Vector2( 468, 2 )
 canHighlight = true
 canClick = true
 
 [node name="Sprite" parent="Interactables/DoorNorthClickable" index="0"]
 material = SubResource( 3 )
-position = Vector2( 160, 12 )
+position = Vector2( 0, -66 )
 texture = ExtResource( 7 )
 
 [node name="CollisionShape2D" parent="Interactables/DoorNorthClickable" index="1"]
-position = Vector2( 159, 11 )
+position = Vector2( -1, -68 )
 shape = SubResource( 4 )
 
 [node name="InteractionPosition" parent="Interactables/DoorNorthClickable" index="2"]
-position = Vector2( 176, 88 )
+position = Vector2( 0, 12 )
 
 [node name="DialogEvent" parent="Interactables/DoorNorthClickable/EventQueue" index="0" instance=ExtResource( 5 )]
 difficulty = 1
@@ -99,25 +99,22 @@ difficulty = 3
 DIALOG = "RandomRoom"
 
 [node name="DoorEastClickable" parent="Interactables" index="1" instance=ExtResource( 2 )]
-position = Vector2( 496, 14 )
+position = Vector2( 961, 187 )
 canHighlight = true
 canClick = true
 
 [node name="Sprite" parent="Interactables/DoorEastClickable" index="0"]
 material = SubResource( 5 )
-position = Vector2( 476, 124 )
+position = Vector2( 2, -60 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 6 )
 
 [node name="CollisionShape2D" parent="Interactables/DoorEastClickable" index="1"]
-position = Vector2( 475.25, 120.313 )
+position = Vector2( 4, -74 )
 shape = SubResource( 6 )
 
 [node name="InteractionPosition" parent="Interactables/DoorEastClickable" index="2"]
-position = Vector2( 450, 190 )
-
-[node name="EventQueue" parent="Interactables/DoorEastClickable" index="3"]
-position = Vector2( 358, -55 )
+position = Vector2( -20, 20 )
 
 [node name="DialogEvent" parent="Interactables/DoorEastClickable/EventQueue" index="0" instance=ExtResource( 5 )]
 difficulty = 1
@@ -208,25 +205,28 @@ position = Vector2( -199, 208 )
 position = Vector2( 590, 1 )
 
 [node name="FloorLampClickable" parent="Interactables" index="6" instance=ExtResource( 12 )]
-position = Vector2( 1163, 367 )
+position = Vector2( 1156, 431 )
 
-[node name="CoffeeTableClickable" parent="Interactables" index="7" instance=ExtResource( 13 )]
+[node name="FloorLampClickable2" parent="Interactables" index="7" instance=ExtResource( 12 )]
+position = Vector2( 727, 558 )
+
+[node name="CoffeeTableClickable" parent="Interactables" index="8" instance=ExtResource( 13 )]
 position = Vector2( 685, 86 )
 
-[node name="CellphoneClickable" parent="Interactables" index="8" instance=ExtResource( 14 )]
+[node name="CellphoneClickable" parent="Interactables" index="9" instance=ExtResource( 14 )]
 position = Vector2( 809, 329 )
 
-[node name="CellphoneClickable2" parent="Interactables" index="9" instance=ExtResource( 14 )]
+[node name="CellphoneClickable2" parent="Interactables" index="10" instance=ExtResource( 14 )]
 position = Vector2( 698, 44 )
 
-[node name="CellphoneClickable3" parent="Interactables" index="10" instance=ExtResource( 14 )]
+[node name="CellphoneClickable3" parent="Interactables" index="11" instance=ExtResource( 14 )]
 position = Vector2( 63, 297 )
 
-[node name="CatLampTalk" parent="Interactables" index="11" instance=ExtResource( 24 )]
+[node name="CatLampTalk" parent="Interactables" index="12" instance=ExtResource( 24 )]
 position = Vector2( 634, 220 )
 
 [node name="ChaseEnemy" parent="." index="4"]
-position = Vector2( 670, 337 )
+position = Vector2( 203, 223 )
 
 [node name="Lamp" parent="Difficulty2" index="0" instance=ExtResource( 9 )]
 position = Vector2( 369, 117 )
@@ -238,7 +238,7 @@ position = Vector2( 744, -80 )
 position = Vector2( 1258, 434 )
 
 [node name="Sleep_Gremlin" parent="Difficulty2" index="3" instance=ExtResource( 8 )]
-position = Vector2( 659, 241 )
+position = Vector2( 780, 451 )
 
 [node name="Sleep_Gremlin" parent="Difficulty3" index="0" instance=ExtResource( 8 )]
 position = Vector2( 304, 19 )

--- a/levels/rooms/UnlikedRoom.tscn
+++ b/levels/rooms/UnlikedRoom.tscn
@@ -195,9 +195,13 @@ position = Vector2( 30, 33 )
 difficulty = 1
 DIALOG = "LivingRoomEast"
 
-[node name="DialogEvent2" parent="Interactables/DoorWestClickable/EventQueue" index="1" instance=ExtResource( 7 )]
+[node name="DialogEvent3" parent="Interactables/DoorWestClickable/EventQueue" index="1" instance=ExtResource( 7 )]
 difficulty = 2
 DIALOG = "Unopenable"
+
+[node name="DialogEvent2" parent="Interactables/DoorWestClickable/EventQueue" index="2" instance=ExtResource( 7 )]
+difficulty = 3
+DIALOG = "RandomRoom"
 
 [node name="CaffeinePillsClickable" parent="Interactables" index="4" instance=ExtResource( 17 )]
 position = Vector2( 2332, 1284 )

--- a/player/Player.gd
+++ b/player/Player.gd
@@ -60,10 +60,11 @@ func _process(delta):
 		# Update the distance to walk
 		distance_to_walk -= distance_to_next_point
 	
-	if Settings.alertnessValue > 0 and path.size() == 0:
-		Settings.alertnessValue -= delta * 5
-	elif Settings.alertnessValue > 0:
-		Settings.alertnessValue -= delta * 1
+	if (Settings.curGameState == Settings.GAME_STATES.PLAY or Settings.curGameState == Settings.GAME_STATES.BATTLE) and Settings.gameStarted:
+		if Settings.alertnessValue > 0 and path.size() == 0:
+			Settings.alertnessValue -= delta * 5.5
+		elif Settings.alertnessValue > 0:
+			Settings.alertnessValue -= delta * 1.5
 
 
 func anim_switch(animation, speed = 1):

--- a/player/Player.tscn
+++ b/player/Player.tscn
@@ -153,7 +153,6 @@ tracks/1/keys = {
 extents = Vector2( 16, 14 )
 
 [node name="Player" type="KinematicBody2D"]
-z_index = 1
 collision_layer = 2
 collision_mask = 5
 script = ExtResource( 2 )

--- a/project.godot
+++ b/project.godot
@@ -249,6 +249,7 @@ Settings="*res://singletons/Settings.gd"
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/screens/ScreenAbout.tscn
+++ b/screens/ScreenAbout.tscn
@@ -13,8 +13,8 @@
 size = 50
 font_data = ExtResource( 4 )
 
-[sub_resource type="DynamicFont" id=1]
-size = 30
+[sub_resource type="DynamicFont" id=3]
+size = 32
 font_data = ExtResource( 8 )
 
 [node name="ScreenMainMenu" instance=ExtResource( 1 )]
@@ -36,46 +36,226 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Panel" type="ScrollContainer" parent="MenuLayer/UIBox/VBoxContainer" index="0"]
+[node name="Label" type="Label" parent="MenuLayer/UIBox/VBoxContainer" index="0"]
+margin_right = 840.0
+margin_bottom = 51.0
+custom_fonts/font = SubResource( 2 )
+text = "Created by  the Tearcell studios"
+align = 1
+
+[node name="Panel" type="ScrollContainer" parent="MenuLayer/UIBox/VBoxContainer" index="1"]
+margin_top = 67.0
 margin_right = 840.0
 margin_bottom = 517.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MenuLayer/UIBox/VBoxContainer/Panel" index="0"]
-margin_right = 750.0
-margin_bottom = 679.0
+margin_right = 824.0
+margin_bottom = 446.0
 rect_min_size = Vector2( 750, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="Label" type="Label" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="0"]
-margin_right = 750.0
-margin_bottom = 51.0
-custom_fonts/font = SubResource( 2 )
-text = "Created by  the Tearcell studios"
-align = 1
-
-[node name="Label2" type="Label" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="1"]
-margin_top = 67.0
-margin_right = 750.0
-margin_bottom = 679.0
+[node name="Credits" type="RichTextLabel" parent="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer" index="0"]
+margin_right = 824.0
+margin_bottom = 446.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 7 )
-custom_fonts/font = SubResource( 1 )
-text = "Meet the Team (scroll for more):
+custom_colors/default_color = Color( 1, 1, 1, 1 )
+custom_fonts/normal_font = SubResource( 3 )
+bbcode_enabled = true
+bbcode_text = "[center][u]Darius de Jesús[/u][/center]
+Lead Coding
+Team Leader and Founder
+Sound Design
+Project Management
+[url=\"https://tearcell.com\"]Website[/url]
+[url=\"https://tearcell.com\"]Itch.io Page[/url]
 
-The Tearcell Founder, Primary Gameplay Designer, and Lead Programmer: Darius DeJesus (tearcell.com)
-Programers: PickyBurrito49, HighVoltageCatfish (@HVCPHD), and Pnutbutterprincess
-Visual Art Design and Composition: Minkies @VixenMink, Ryan (Ryan@scorchedmountaingames@gmail.com), and Pnutbutterprincess
-UI/UX Design: Babs
-Writing Team: MTBVibe & HighVoltageCatfish (@HVCPHD)
-Sound Design: MTBVibe
-For Additional Attributions, please vist the game page on Itch.io!"
-align = 1
-valign = 1
-autowrap = true
+[center][u]Pickyburrito49[/u][/center]
+Additional Coding, 
+Community Relations
+[url=\"pickyburrito49.itch.io\"]Itch.io Page[/url]
 
-[node name="BtnBack" parent="MenuLayer/UIBox/VBoxContainer" index="1" instance=ExtResource( 5 )]
+[center][u]Whiskeybadger[/u][/center]
+Character Design, 
+Visual Design, 
+Art Direction, 
+Art Assets, 
+Animation
+Email - Ryan@scorchedmountaingames@gmail.com
+
+[center][u]Minkies[/u][/center]
+Visual Design, 
+Art Assets, 
+Animation, 
+Community Relations
+@VixenMink
+[url=\"https://www.instagram.com/vixenmink/\"]Instagram[/url]
+[url=\"https://vixenmink.wordpress.com/vm_portfolio/\"]Website[/url]
+
+[center][u]Pnutbutterprincess[/u][/center]
+Additional Coding, 
+Additional Art Assets
+
+[center][u]HighVoltageCatfish[/u][/center]
+Level Design, 
+Writing, 
+Godot Key Animation, 
+Data Repository Manager
+[url=\"https://psyenproject.com/\"]Website[/url]
+Twitter - @HVCPHD
+
+[center][u]MTBVibe[/u][/center]
+Sound Design, 
+Writing,
+Data Repository Manager
+[url=\"twitch.tv/mtbvibe\"]Twitch[/url]
+
+[center][u]Babs[/u][/center]
+UI/UX Design
+
+
+[u]Sound Attributions[/u]
+Somnipathy uses the following sounds from freesound under [url=\"https://creativecommons.org/licenses/by/3.0/legalcode]CC BY 3.0[/url]. These sounds may have been adapted, edited, remixed, adjusted for in-engine use, or some/all of the above
+  
+[url=\"https://freesound.org/people/columbia23/sounds/395395/]Spider Voice.wav[/url] by [url=\"https://freesound.org/people/columbia23/]columbia23[/url];
+[url=\"https://freesound.org/people/GioMilko/sounds/344690/]Atonal Electric Guitar Riff[/url] by [url=\"https://freesound.org/people/GioMilko/]GioMilko[/url];
+[url=\"https://freesound.org/people/GlennM/sounds/386530/]breathing_heavy.wav[/url] by [url=\"https://freesound.org/people/GlennM/]GlennM[/url];
+[url=\"https://freesound.org/people/kelsey_w/sounds/467042/]Crowd Laugh.wav[/url] by [url=\"https://freesound.org/people/kelsey_w/]kelsey_w[/url];
+[url=\"https://freesound.org/people/lonce/sounds/200426/]CreakyDoorFast.wav[/url] by [url=\"https://freesound.org/people/lonce/]lonce[/url];
+[url=\"https://freesound.org/people/michaelkoehler/sounds/201952/]Castanets clapping[/url] by [url=\"https://freesound.org/people/michaelkoehler/]michaelkoehler[/url];
+[url=\"https://freesound.org/people/mkoenig/sounds/78469/]Slurping Sound.wav 6066.wav[/url] by [url=\"https://freesound.org/people/mkoenig/]mkoenig[/url];
+[url=\"https://freesound.org/people/sinatra314/sounds/58454/]footsteps wooden floor loop.wav[/url] by [url=\"https://freesound.org/people/sinatra314/]sinatra314[/url];
+[url=\"https://freesound.org/people/sjturia/sounds/370914/]door_opening_creaky.wav[/url] by [url=\"https://freesound.org/people/sjturia/]sjturia[/url];
+[url=\"https://freesound.org/people/SophieMezaM/sounds/446083/]whispers.wav[/url] by [url=\"https://freesound.org/people/SophieMezaM/]SophieMezaM[/url];
+[url=\"https://freesound.org/people/test_sound/sounds/464268/]Metal Light Switch.wav[/url] by [url=\"https://freesound.org/people/test_sound/]test_sound[/url]; 
+and [url=\"https://freesound.org/people/zerolagtime/sounds/106607/]drum8.wav[/url] by [url=\"https://freesound.org/people/zerolagtime/]zerolagtime[/url]
+  
+Somnipathy uses the following sounds from freesound under [url=\"https://creativecommons.org/licenses/by-nc/3.0/legalcode]CC BY-NC 3.0[/url]. These sounds may have been adapted, edited, remixed, adjusted for in-engine use, or some/all of the above
+[url=\"https://freesound.org/people/Joao_Janz/sounds/485213/]Wood Surface Hit 1_4[/url] by [url=\"https://freesound.org/people/Joao_Janz/]Joao_Janz[/url];
+[url=\"https://freesound.org/people/Mega-X-stream/sounds/546278/]Futuristic Woosh sound[/url] by [url=\"https://freesound.org/people/Mega-X-stream/]Mega-X-stream[/url]; 
+and [url=\"https://freesound.org/people/zagi2/sounds/505293/]Incubus.wav[/url] by [url=\"https://freesound.org/people/zagi2/]zagi2[/url].
+  
+Somnipathy also uses a number of other sounds accessed via freesound that are available under [url=\"https://creativecommons.org/publicdomain/zero/1.0/legalcode]CC0[/url]. Please visit [url=\"https://freesound.org/]freesound[/url] to learn more about how awesome a resource it is for projects like this one. Those sounds also may have been adapted, edited, remixed, or adjusted for in-engine use, or some/all of the above.
+
+The following fonts were used within Somnipathy
+[u]Rubik Glitch[/u]
+Copyright 2020 The Rubik Filtered Project Authors (https://https://github.com/NaN-xyz/Rubik-Filtered)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+[u]Love ya like a sister[/u]
+Copyright (c) 2010, Kimberly Geswein (kimberlygeswein.com)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+[u]Sofija[/u]
+Sofija is licensed under the 1001Fonts Free For Commercial Use License (FFC)
+
+
+Somnipathy was programmed in the Godot engine and used the following plugins
+[url=\"https://github.com/MakovWait/improved_resource_picker\"]Improved Resource[/url] Picker by MakovWait
+[url=\"https://github.com/3ddelano/godot-editor-discord-presence\"]Godot Editor Presence[/url] by 3ddelano
+[url=\"https://github.com/coppolaemilio/dialogic\"]Dialogic[/url] by Emillio Coppola
+[url=\"https://github.com/AnJ95/godot-toolbox-project\"]The Godot Toolbox Project[/url] by AnJ95
+[url=\"https://silentwolf.com/\"]SilentWolf Backend Services[/url]"
+text = "Darius de Jesús
+Lead Coding
+Team Leader and Founder
+Sound Design
+Project Management
+Website
+Itch.io Page
+
+Pickyburrito49
+Additional Coding, 
+Community Relations
+Itch.io Page
+
+Whiskeybadger
+Character Design, 
+Visual Design, 
+Art Direction, 
+Art Assets, 
+Animation
+Email - Ryan@scorchedmountaingames@gmail.com
+
+Minkies
+Visual Design, 
+Art Assets, 
+Animation, 
+Community Relations
+@VixenMink
+Instagram
+Website
+
+Pnutbutterprincess
+Additional Coding, 
+Additional Art Assets
+
+HighVoltageCatfish
+Level Design, 
+Writing, 
+Godot Key Animation, 
+Data Repository Manager
+Website
+Twitter - @HVCPHD
+
+MTBVibe
+Sound Design, 
+Writing,
+Data Repository Manager
+Twitch
+
+Babs
+UI/UX Design
+
+
+Sound Attributions
+Somnipathy uses the following sounds from freesound under CC BY 3.0. These sounds may have been adapted, edited, remixed, adjusted for in-engine use, or some/all of the above
+  
+Spider Voice.wav by columbia23;
+Atonal Electric Guitar Riff by GioMilko;
+breathing_heavy.wav by GlennM;
+Crowd Laugh.wav by kelsey_w;
+CreakyDoorFast.wav by lonce;
+Castanets clapping by michaelkoehler;
+Slurping Sound.wav 6066.wav by mkoenig;
+footsteps wooden floor loop.wav by sinatra314;
+door_opening_creaky.wav by sjturia;
+whispers.wav by SophieMezaM;
+Metal Light Switch.wav by test_sound; 
+and drum8.wav by zerolagtime
+  
+Somnipathy uses the following sounds from freesound under CC BY-NC 3.0. These sounds may have been adapted, edited, remixed, adjusted for in-engine use, or some/all of the above
+Wood Surface Hit 1_4 by Joao_Janz;
+Futuristic Woosh sound by Mega-X-stream; 
+and Incubus.wav by zagi2.
+  
+Somnipathy also uses a number of other sounds accessed via freesound that are available under CC0. Please visit freesound to learn more about how awesome a resource it is for projects like this one. Those sounds also may have been adapted, edited, remixed, or adjusted for in-engine use, or some/all of the above.
+
+The following fonts were used within Somnipathy
+Rubik Glitch
+Copyright 2020 The Rubik Filtered Project Authors (https://https://github.com/NaN-xyz/Rubik-Filtered)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+Love ya like a sister
+Copyright (c) 2010, Kimberly Geswein (kimberlygeswein.com)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+Sofija
+Sofija is licensed under the 1001Fonts Free For Commercial Use License (FFC)
+
+
+Somnipathy was programmed in the Godot engine and used the following plugins
+Improved Resource Picker by MakovWait
+Godot Editor Presence by 3ddelano
+Dialogic by Emillio Coppola
+The Godot Toolbox Project by AnJ95
+SilentWolf Backend Services"
+
+[node name="BtnBack" parent="MenuLayer/UIBox/VBoxContainer" index="2" instance=ExtResource( 5 )]
 margin_top = 533.0
 margin_right = 840.0
 margin_bottom = 560.0
@@ -84,3 +264,5 @@ pushes_screen = false
 screen_to_push_in_config = ""
 pops_screen = true
 grabs_focus = true
+
+[connection signal="meta_clicked" from="MenuLayer/UIBox/VBoxContainer/Panel/VBoxContainer/Credits" to="." method="_on_Credits_meta_clicked"]

--- a/singletons/Settings.gd
+++ b/singletons/Settings.gd
@@ -108,11 +108,11 @@ func adjust_score(value: String):
 	var fct = get_parent().get_node('ScreenGame/GameMain/').get_child(4).get_node('Player/Floating_Text_Manager')
 	fct.show_value(value, 0)
 	print('Sanity Adjusted: ', score)
-	
 
 
 func _process(delta):
-	score += delta
+	if (curGameState == GAME_STATES.PLAY or curGameState == GAME_STATES.BATTLE) and gameStarted:
+		score += delta
 	if roomsExplored >= 3 and roomsExplored < 10 and difficulty == 1:
 		difficulty = 2
 	elif roomsExplored >= 8:


### PR DESCRIPTION
Fixed Cellphone interaction (was +50 score, -50 alert => now +50 score, -1 sanity)
Fixed lamp/light switch interaction (was +15 sanity, now +15 alert)
Slightly sped up BOTH you and the enemy (starting values were 25 and 75, now 35 and 85)
Slightly sped up natural Alert decay (was 1 moving, 5 standing; now 1.5 moving, 5.5 standing)
Provided feedback as to why you got a gameover
Fixed a reported crash bug (the 'event' runner would sometimes try to reference a freed event if you clicked really fast)
Fixed a reported issue with Windows 11 executable (game would run, but start wouldn't work)
Fixed a bug where the enemy spawn timer would continue even if the game was paused
Fixed some (but not all) sprite Ysorting bugs
Fixed missing attribution in about page